### PR TITLE
Update meson build and translation scripts

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -25,8 +25,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.3
         with:
-          bundle: io.github.amit9838.weather.flatpak
-          manifest-path: io.github.amit9838.weather.json
+          bundle: io.github.amit9838.mousam.flatpak
+          manifest-path: io.github.amit9838.mousam.json
           cache-key: flatpak-builder-${{ github.sha }}
           arch: ${{ matrix.arch }}
           restore-cache: true

--- a/data/icons/meson.build
+++ b/data/icons/meson.build
@@ -9,61 +9,24 @@ install_data(
 
 scalable_dir = join_paths('hicolor','scalable', 'mousam_icons')
 
-install_data(
-	  join_paths(scalable_dir, 'arrow.svg'),
-    
-	  join_paths(scalable_dir, 'clear-day.svg'),
-    join_paths(scalable_dir, 'clear-night.svg'),
-    join_paths(scalable_dir, 'partly-cloudy-day.svg'),
-    join_paths(scalable_dir, 'drizzle.svg'),
-    join_paths(scalable_dir, 'overcast-drizzle.svg'),
-    join_paths(scalable_dir, 'partly-cloudy-day-drizzle.svg'),
-    join_paths(scalable_dir, 'partly-cloudy-night-drizzle.svg'),
-    join_paths(scalable_dir, 'partly-cloudy-night.svg'),
-    join_paths(scalable_dir, 'overcast.svg'),
-    join_paths(scalable_dir, 'overcast-day.svg'),
-    join_paths(scalable_dir, 'overcast-night.svg'),
-    join_paths(scalable_dir, 'fog.svg'),
-    join_paths(scalable_dir, 'fog-day.svg'),
-    join_paths(scalable_dir, 'fog-night.svg'),
-    join_paths(scalable_dir, 'overcast-fog.svg'),
-    join_paths(scalable_dir, 'overcast-day-fog.svg'),
-    join_paths(scalable_dir, 'overcast-night-fog.svg'),
-    join_paths(scalable_dir, 'partly-cloudy-day-fog.svg'),
-    join_paths(scalable_dir, 'partly-cloudy-night-fog.svg'),
-    join_paths(scalable_dir, 'rain.svg'),
-    join_paths(scalable_dir, 'wind.svg'),
-    join_paths(scalable_dir, 'raindrop.svg'),
-    join_paths(scalable_dir, 'raindrops.svg'),
-    join_paths(scalable_dir, 'overcast-rain.svg'),
-    join_paths(scalable_dir, 'overcast-day-rain.svg'),
-    join_paths(scalable_dir, 'overcast-night-rain.svg'),
-    join_paths(scalable_dir, 'thunderstorms-rain.svg'),
-    join_paths(scalable_dir, 'partly-cloudy-day-rain.svg'),
-    join_paths(scalable_dir, 'partly-cloudy-night-rain.svg'),
-    join_paths(scalable_dir, 'thunderstorms.svg'),
-    join_paths(scalable_dir, 'thunderstorms-day-rain.svg'),
-    join_paths(scalable_dir, 'thunderstorms-night-rain.svg'),
-    join_paths(scalable_dir, 'thunderstorms-overcast-rain.svg'),
-    join_paths(scalable_dir, 'thunderstorms-day-overcast-rain.svg'),
-    join_paths(scalable_dir, 'thunderstorms-night-overcast-rain.svg'),
-    join_paths(scalable_dir, 'snow.svg'),
-    join_paths(scalable_dir, 'snowflake.svg'),
-    join_paths(scalable_dir, 'overcast-snow.svg'),
-    join_paths(scalable_dir, 'overcast-day-snow.svg'),
-    join_paths(scalable_dir, 'overcast-night-snow.svg'),
-    join_paths(scalable_dir, 'thunderstorms-snow.svg'),
-    join_paths(scalable_dir, 'partly-cloudy-day-snow.svg'),
-    join_paths(scalable_dir, 'partly-cloudy-night-snow.svg'),
-    join_paths(scalable_dir, 'thunderstorms-day-snow.svg'),
-    join_paths(scalable_dir, 'thunderstorms-night-snow.svg'),
-    join_paths(scalable_dir, 'thunderstorms-overcast-snow.svg'),
-    join_paths(scalable_dir, 'thunderstorms-day-overcast-snow.svg'),
-    join_paths(scalable_dir, 'thunderstorms-night-overcast-snow.svg'),
-
-	install_dir: join_paths(get_option('datadir'), 'icons', scalable_dir),
-
+fs = import('fs')
+source_svgs = []
+source_svgs += files(
+  run_command(
+    'find',
+    meson.current_source_dir() / scalable_dir,
+    '-name', '*.svg',
+    check: true
+  ).stdout().strip().split('\n')
 )
+
+foreach i : range(source_svgs.length())
+  svg = source_svgs[i]
+  install_data(
+    join_paths(scalable_dir, fs.name(svg)),
+	  install_dir: join_paths(get_option('datadir'), 'icons', scalable_dir)
+  )
+endforeach
 
 symbolic_dir = join_paths('hicolor', 'symbolic', 'apps')
 install_data(

--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,7 @@ subdir('data')
 subdir('src')
 subdir('po')
 
-install_subdir('data/mousam_icons', install_dir: get_option('datadir') / 'icons/hicolor/scalable')
+install_emptydir(get_option('datadir') / 'icons/hicolor/scalable')
 
 gnome.post_install(
      glib_compile_schemas: true,

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,7 +23,7 @@ configure_file(
   configuration: conf,
   install: true,
   install_dir: get_option('bindir'),
-  install_mode: 'r-xr-xr--'
+  install_mode: 'rwxr-xr--'
 )
 
 mousam_sources = [

--- a/update-pot
+++ b/update-pot
@@ -1,0 +1,2 @@
+#!/bin/bash
+xgettext --keyword=_ --keyword=N_ --output=po/mousam.pot -f po/POTFILES


### PR DESCRIPTION
- Concise the meson build script for icons
- Fix install mode for the mousam binary
- Replace deprecated meson function install_subdir with install_emptydir
- Update flatpak builder workflow
- Closed #57 with #65