### PR TITLE
Translation related patches

### DIFF
--- a/data/io.github.amit9838.mousam.appdata.xml.in
+++ b/data/io.github.amit9838.mousam.appdata.xml.in
@@ -43,6 +43,9 @@
   <url type="translate">https://github.com/amit9838/mousam/tree/master/po</url>
   <url type="vcs-browser">https://github.com/amit9838/mousam</url>
   <developer_name>Amit Chaudhary</developer_name>
+  <developer id="io.github.amit9838">
+    <name translate="no">Amit Chaudhary</name>
+  </developer>
   <recommends>
     <control>pointing</control>
     <control>touch</control>

--- a/data/io.github.amit9838.mousam.appdata.xml.in
+++ b/data/io.github.amit9838.mousam.appdata.xml.in
@@ -56,7 +56,7 @@
   <content_rating type="oars-1.1" />
   <releases>
      <release version="1.1.0" date="2024-02-24">
-      <description translatable="no">
+      <description translate="no">
         <p>What's New</p>
         <ul>
           <li>Dynamic background is back again, app background changes based on current weather condition.</li>
@@ -78,7 +78,7 @@
       </description>
     </release>
     <release version="1.0.2" date="2024-02-8">
-      <description translatable="no">
+      <description translate="no">
         <p>Bug fixes</p>
         <ul>
           <li>Bug fixes related to build</li>
@@ -91,7 +91,7 @@
       </description>
     </release>
     <release version="1.0.1" date="2024-01-16">
-      <description translatable="no">
+      <description translate="no">
         <p>Bug fixes</p>
         <ul>
           <li>Fix bug where some locations dosen't provide valid co-ordinates</li>
@@ -100,7 +100,7 @@
       </description>
     </release>
     <release version="1.0.0" date="2024-01-14">
-      <description translatable="no">
+      <description translate="no">
         <p>What's New</p>
         <ul>
           <li>Introducing a new design with an entirely new app experience.</li>
@@ -124,7 +124,7 @@
       </description>
     </release>
     <release version="0.6.0" date="2023-07-14">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Adds air-pollution info</li>
           <li>Adds Snowfall summary</li>
@@ -136,7 +136,7 @@
       </description>
     </release>
     <release version="0.5.0" date="2023-07-05">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Adds sunset/sunrise info</li>
           <li>Add and remove city more quickly</li>
@@ -147,7 +147,7 @@
       </description>
     </release>
     <release version="0.4.0" date="2023-06-25">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Adds 5 days forecast</li>
           <li>Adds rain summary (rain quantity)</li>
@@ -158,7 +158,7 @@
       </description>
     </release>
     <release version="0.3.0" date="2023-06-22">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Show today and tomorrow forecasts</li>
           <li>Option:Use Imerial, Metric systems</li>
@@ -173,7 +173,7 @@
       </description>
     </release>
     <release version="0.2.1" date="2023-06-18">
-      <description translatable="no">
+      <description translate="no">
         <ul>
           <li>Use full country name.</li>
           <li>Fix units.</li>
@@ -183,7 +183,7 @@
       </description>
     </release>
     <release version="0.2.0" date="2023-06-17">
-      <description translatable="no">
+      <description translate="no">
         <p>What's New</p>
         <ul>
           <li>Option:Use Custom api-key.</li>
@@ -196,7 +196,7 @@
       </description>
     </release>
     <release version="0.1.0" date="2023-06-11">
-      <description translatable="no">
+      <description translate="no">
         <p>New features and updates</p>
         <ul>
           <li>Use dynamic gradient backgrounds based on current weather.</li>

--- a/src/frontendForecast.py
+++ b/src/frontendForecast.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 import gi
 from gi.repository import Gtk
-from gettext import gettext as _
+from gettext import gettext as _, pgettext as C_
 from .constants import icons
 from .utils import is_dynamic_bg_enabled
 

--- a/src/frontendHourlyDetails.py
+++ b/src/frontendHourlyDetails.py
@@ -92,7 +92,7 @@ class HourlyDetails(Gtk.Grid):
         info_grid = Gtk.Grid(margin_start=20, margin_top=10)
         page_grid.attach(info_grid, 0, 1, 1, 1)
 
-        desc_label = Gtk.Label(label=gettext.pgettext("wind", "Day High"), halign=Gtk.Align.START)
+        desc_label = Gtk.Label(label=C_("wind", "Day High"), halign=Gtk.Align.START)
         desc_label.set_css_classes(["text-4", "light-2", "bold-2"])
         info_grid.attach(desc_label, 0, 0, 3, 1)
 
@@ -108,7 +108,7 @@ class HourlyDetails(Gtk.Grid):
 
         # Hourly Page
         if page_name == "hourly":
-            desc_label.set_text(gettext.pgettext("temperature","Day Max"))
+            desc_label.set_text(C_("temperature","Day Max"))
             val_label.set_text(str(max(hourly_data.temperature_2m.get("data"))) + "°")
             unit_label.set_text("")
 
@@ -123,7 +123,7 @@ class HourlyDetails(Gtk.Grid):
             unit = "inch"
 
         if page_name == "prec":
-            desc_label.set_text(gettext.pgettext("precipitation","Day High"))
+            desc_label.set_text(C_("precipitation","Day High"))
             val_label.set_text(f"{max_prec:.2f}")
             unit_label.set_text(unit)
 

--- a/src/mousam.py
+++ b/src/mousam.py
@@ -274,8 +274,8 @@ class WeatherMainWindow(Gtk.ApplicationWindow):
             main_val_unit="",
             desc=cw_data.surface_pressure.get("unit"),
             sub_desc_heading=cw_data.surface_pressure.get("level_str"),
-            text_up=gettext.pgettext("pressure card", "High"),
-            text_low=gettext.pgettext("pressure card", "Low"),
+            text_up=C_("pressure card", "High"),
+            text_low=C_("pressure card", "Low"),
         )
         widget_grid.attach(card_obj.card, 0, 1, 1, 1)
 
@@ -284,8 +284,8 @@ class WeatherMainWindow(Gtk.ApplicationWindow):
             title="UV Index",
             main_val=cw_data.uv_index.get("data"),
             desc=cw_data.uv_index.get("level_str"),
-            text_up=gettext.pgettext("uvindex card","High"),
-            text_low=gettext.pgettext("uvindex card", "Low"),
+            text_up=C_("uvindex card","High"),
+            text_low=C_("uvindex card", "Low"),
         )
         widget_grid.attach(card_obj.card, 1, 1, 1, 1)
 

--- a/src/weatherData.py
+++ b/src/weatherData.py
@@ -115,33 +115,33 @@ def classify_aqi(aqi_value):
 
 def classify_uv_index(uv_index):
     if uv_index <= 2:
-        return gettext.pgettext("uvindex", "Low")
+        return C_("uvindex", "Low")
     elif uv_index <= 5:
-        return gettext.pgettext("uvindex", "Moderate")
+        return C_("uvindex", "Moderate")
     elif uv_index <= 7:
-        return gettext.pgettext("uvindex", "High")
+        return C_("uvindex", "High")
     elif uv_index <= 10:
-        return gettext.pgettext("uvindex", "Very High")
+        return C_("uvindex", "Very High")
     else:
-        return gettext.pgettext("uvindex", "Extreme")
+        return C_("uvindex", "Extreme")
 
 
 def classify_humidity_level(uv_index):
     if uv_index < 50:
-        return gettext.pgettext("humidity", "Low")
+        return C_("humidity", "Low")
     elif uv_index <= 80:
-        return gettext.pgettext("humidity", "Moderate")
+        return C_("humidity", "Moderate")
     else:
-        return gettext.pgettext("humidity", "High")
+        return C_("humidity", "High")
 
 
 def classify_presssure_level(pressure):
     if pressure < 940:
-        return gpettext.pgettext("pressure", "Low")
+        return C_("pressure", "Low")
     elif pressure <= 1010:
-        return gettext.pgettext("pressure", "Normal")
+        return C_("pressure", "Normal")
     else:
-        return gettext.pgettext("pressure", "High")
+        return C_("pressure", "High")
 
 
 def classify_wind_speed_level(wind_speed):
@@ -150,11 +150,11 @@ def classify_wind_speed_level(wind_speed):
     elif wind_speed <= 25:
         return _("Light")
     elif wind_speed <= 40:
-        return gettext.pgettext("wind", "Moderate")
+        return C_("wind", "Moderate")
     elif wind_speed <= 60:
         return _("Strong")
     else:
-        return gettext.pgettext("wind", "Extreme")
+        return C_("wind", "Extreme")
 
 
 def transform_visibility_data(unit, data):

--- a/update-pot
+++ b/update-pot
@@ -1,2 +1,2 @@
 #!/bin/bash
-xgettext --keyword=_ --keyword=N_ --keyword=pgettext:1c,2 --output=po/mousam.pot -f po/POTFILES
+xgettext --keyword=_ --keyword=N_ --keyword=C_:1c,2 --output=po/mousam.pot -f po/POTFILES


### PR DESCRIPTION
### appdata: `translate=no` properties

It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: `https://github.com/ximion/appstream/issues/623`

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html

### appdata: Add developer ID

Flathub requires a developer tag and developer ID.

> A developer tag with a name child tag must be present. Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```

Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name

## i18n: Use C_ alias for pgettext 

That way it's easy to catch a translatable string.
