### PR TITLE
Add scrollbar offset logic in HourlyDetails widget

### DIFF
--- a/src/frontendHourlyDetails.py
+++ b/src/frontendHourlyDetails.py
@@ -261,3 +261,9 @@ class HourlyDetails(Gtk.Grid):
 
                 label_val.set_margin_top(0)
 
+        # Add scrollbar offset
+        container_size = graphic_container.get_preferred_size()[1]
+        container_width = container_size.width
+        scrollbar_offset = (container_width / 24) * (nearest_current_time_idx - 2)
+        h_adjustment = Gtk.Adjustment(value=scrollbar_offset, lower=0, upper=container_width)
+        scrolled_window.set_hadjustment(h_adjustment)


### PR DESCRIPTION
This pull request adds functionality to the HourlyDetails widget in order to properly handle scrollbar positioning based on the nearest current time index.

`get_preferred_size()` returns a tuple containing the minimum and the natural size of the widget (width and height), so i accessed directly the natural size and retrieved the width:
`container_size = graphic_container.get_preferred_size()[1]`
`container_width = container_size.width`

Then i calculate the offset based on the container width and the nearest current time index. It substracts 2 to leave the last 2 cards before the current time visible:
`scrollbar_offset = (container_width / 24) * (nearest_current_time_idx - 2)`

In the end i created Gtk adjustment for the horizontal scrollbar, setting its value to the calculated scrollbar offset and ensuring it remains within the bounds of 0 and the width of the container:
`h_adjustment = Gtk.Adjustment(value=scrollbar_offset, lower=0, upper=container_width)`
`scrolled_window.set_hadjustment(h_adjustment)`

Note: In case `nearest_current_time_idx` will be 0 or 1, the scrollbar_offset will have a negative value which means the scrollbar will be positioned at the extreme left, so we don't have to handle this case separately. Also the code is positioned at the end of the file because it relies on the initialization of UI elements which occur just before.