### PR TITLE
fixed 24-hour format not working for sunrise/sunset

### DIFF
--- a/src/frontendCardDayNight.py
+++ b/src/frontendCardDayNight.py
@@ -41,8 +41,15 @@ class CardDayNight:
                 sunset_ts = daily_data.sunset.get("data")[i]
                 break
 
-        sunrise = datetime.fromtimestamp(sunrise_ts - time_diff).strftime("%I:%M %p")
-        sunset = datetime.fromtimestamp(sunset_ts - time_diff).strftime("%I:%M %p")
+        sunrise_dt = datetime.fromtimestamp(sunrise_ts - time_diff)
+        sunset_dt = datetime.fromtimestamp(sunset_ts - time_diff)
+
+        sunrise = sunrise_dt.strftime("%I:%M %p")
+        sunset = sunset_dt.strftime("%I:%M %p")
+
+        if settings.is_using_24h_clock:
+            sunrise = sunrise_dt.strftime("%H:%M")
+            sunset = sunset_dt.strftime("%H:%M")
 
         # Caclulate Sun rotation
         degree = 0


### PR DESCRIPTION
Fixes #136

It might be better to have a function which only converts any date/timestamp to the correct format selected by the user in the future. The code snippet I added can be found at multiple places within the source code (in different files), which makes it harder to change and maintain if something is changed (e.g. the settings class). Having it in just one function and then calling that with the date/timestamp as an input makes it easier and less prone to bugs like this.