### PR TITLE
Added spacing between names of places.

### DIFF
--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,0 +1,5 @@
+rm -rf builddir
+meson setup -Dprefix=$HOME/.local builddir
+meson compile -C builddir --verbose
+meson install -C builddir
+mousam

--- a/src/frontendCurrentCond.py
+++ b/src/frontendCurrentCond.py
@@ -78,7 +78,7 @@ class CurrentCondition(Gtk.Grid):
         del city_arr[-1]
         del city_arr[-1]
 
-        current_loc = ",".join(city_arr)
+        current_loc = ", ".join(city_arr)
         loc_label = Gtk.Label(label=current_loc, halign=Gtk.Align.END, margin_bottom=20)
         loc_label.set_css_classes(["text-2b", "bold-2"])
         box_right.append(loc_label)

--- a/src/windowLocations.py
+++ b/src/windowLocations.py
@@ -77,10 +77,10 @@ class WeatherLocations(Adw.PreferencesWindow):
             box.append(button)
 
             # Location Row
-            location_row =  Adw.ActionRow.new()
+            location_row = Adw.ActionRow.new()
             location_row.set_activatable(True)
-            location_row.set_title(f"{city.split(',')[0]},{city.split(',')[1]}")
-            location_row.set_subtitle(f"{city.split(',')[-2]},{city.split(',')[-1]}")
+            location_row.set_title(f"{city.split(',')[0]}, {city.split(',')[1]}")
+            location_row.set_subtitle(f"{city.split(',')[-2]}, {city.split(',')[-1]}")
             location_row.add_suffix(box)
             
             # Location row signal
@@ -188,7 +188,7 @@ class WeatherLocations(Adw.PreferencesWindow):
                 res_row.set_activatable(True)
                 title_arr = [loc.name,loc.state,loc.country]
                 title_arr = [x for x in title_arr if x is not None]
-                title = ",".join(title_arr)
+                title = ", ".join(title_arr)
                 res_row.set_title(title)
 
                 # Skip plotting the location in the search results if it has invalid cords
@@ -236,7 +236,7 @@ class WeatherLocations(Adw.PreferencesWindow):
             city = f"{widget.get_title()},{widget.get_subtitle()}"
 
             # Don't delete city if only one item is present in the list
-            if len(added_cities)==1:
+            if len(added_cities) == 1:
                 self.add_toast(create_toast(_("Add more locations to delete!"),1))
                 return
 


### PR DESCRIPTION
There should be a space after the comma when listing a location sequentially. I have added this in the "add city" and home pages. See below:
# Before
![image](https://github.com/user-attachments/assets/2330dec7-021a-4790-96ae-bbe297b4f921)
# After
![image](https://github.com/user-attachments/assets/f9840927-9b0a-4b35-82bf-dee0f0c07e74)

I also added a little script so that the build can be done in one command.