### PR TITLE
fix #166: hourly weather API parameter `timezone=auto`

### DIFF
--- a/src/backendWeather.py
+++ b/src/backendWeather.py
@@ -62,7 +62,7 @@ class Weather:
     # Hourly Forecast ==============================================
     @classmethod
     def forecast_hourly(cls,latitude: float, longitude: float, **kwargs):
-        url = base_url + f"?latitude={latitude}&longitude={longitude}"
+        url = base_url + f"?latitude={latitude}&longitude={longitude}&timezone=auto"
 
         # Check for kwargs keyword parameters
         if "hourly" in kwargs:


### PR DESCRIPTION
Very minimal patch just adding the API parameter `timezone=auto` to the hourly forecast request.
I built and ran the flatpak and it seems to work.
I can tell that near midnight, the problem would arise that the hourly forecast doesn't forecast into the next day, but maybe that's a separate issue. Thanks @roshanshariff for prescribing the solution!