### PR TITLE
feat(ui-forecast): remove bottom margin on forecast GtkBox

### DIFF
--- a/src/UI_Forecast.py
+++ b/src/UI_Forecast.py
@@ -86,7 +86,6 @@ class Forecast(Gtk.Grid):
     def _setup_styling(self) -> None:
         """Apply margins and CSS classes to the widget."""
         self.set_margin_top(10)
-        self.set_margin_bottom(5)
         self.set_margin_start(6)
         self.set_margin_end(3)
 


### PR DESCRIPTION
Great weather app. Everything looks clean, but there's a small height inconsistency with the forecast GtkBox (see following image).

<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/60d4309d-58b3-4dd8-84c8-c55865a8b787" />

This PR simply removes the bottom margin on the forecast box to make it equally as tall as the other elements and therefore more uniform. Preview:

<img width="2020" height="1620" alt="image" src="https://github.com/user-attachments/assets/c83bc29a-2159-4b5c-892e-b62757bfe8b4" />