### PR TITLE
Fix Wind/Precipitation and Weekly tabs silently failing due to weak_connect() GC bug

### DIFF
--- a/src/UI_Forecast.py
+++ b/src/UI_Forecast.py
@@ -141,7 +141,7 @@ class Forecast(Gtk.Grid):
         tomorrow_btn.set_size_request(self.ITEM_WIDTH_REQUEST, self.ITEM_HEIGHT_REQUEST)
         tomorrow_btn.set_css_classes(["btn-sm"])
         tomorrow_btn.set_active(True)
-        weak_connect(tomorrow_btn, "clicked", self._on_tomorrow_clicked)
+        tomorrow_btn.connect("clicked", self._on_tomorrow_clicked)
         button_bar.append(tomorrow_btn)
 
         # Weekly button (grouped with tomorrow)
@@ -149,7 +149,7 @@ class Forecast(Gtk.Grid):
         weekly_btn.set_size_request(self.ITEM_WIDTH_REQUEST, self.ITEM_HEIGHT_REQUEST)
         weekly_btn.set_css_classes(["btn-sm"])
         weekly_btn.set_group(tomorrow_btn)
-        weak_connect(weekly_btn, "clicked", self._on_weekly_clicked)
+        weekly_btn.connect("clicked", self._on_weekly_clicked)
         button_bar.append(weekly_btn)
 
         return button_bar

--- a/src/UI_HourlyDetails.py
+++ b/src/UI_HourlyDetails.py
@@ -64,7 +64,7 @@ class HourlyDetails(Gtk.Grid):
                 button.set_group(first_btn)
             style_buttons_box.append(button)
             button._page_name = page_name  # store for use in handler
-            weak_connect(button, "clicked", self._on_btn_clicked)
+            button.connect("clicked", self._on_btn_clicked)
 
         # Initialize with first tab
         if first_btn:
@@ -178,7 +178,7 @@ class HourlyDetails(Gtk.Grid):
 
         controller = Gtk.EventControllerScroll.new(Gtk.EventControllerScrollFlags.BOTH_AXES)
         scrolled_window.add_controller(controller)
-        weak_connect(controller, "scroll", self.on_scroll)
+        controller.connect("scroll", self.on_scroll)
 
         graphic_container = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         scrolled_window.set_child(graphic_container)


### PR DESCRIPTION
## Problem
Clicking the Wind or Precipitation tab in the hourly forecast panel did nothing —
the display stayed frozen on temperature/icon data. Similarly, clicking Weekly in
the forecast panel kept showing Tomorrow's hourly data instead of the 7-day forecast.
No errors appeared in the terminal, even with debug logging enabled.

## Root cause
`weak_connect()` in `CORE_GTKUtils.py` stores only a `weakref` to the bound
method's `self`. GTK's C-level widget tree can keep a widget alive on screen
independent of whether anything holds a strong Python reference to its wrapper
object. When the Python wrapper gets garbage collected while the widget is
still visible, the signal handler's weakref resolves to `None` and the handler
silently no-ops — no exception, no log output, just nothing happens.

This affected three call sites:
- `UI_HourlyDetails.py`: Wind/Precipitation tab buttons
- `UI_Forecast.py`: Tomorrow/Weekly tab buttons  
- `UI_HourlyDetails.py`: scroll controller for the hourly list

The initial "Hourly" and "Tomorrow" views were unaffected because they're
populated by direct synchronous calls during initialization, not through
these signal connections.

## Fix
Switched these three connections from `weak_connect()` to direct `.connect()`.
These are UI widgets whose signal handlers only need to remain valid for as
long as the widget itself is on screen and part of the visible widget tree —
the weak-reference protection isn't providing meaningful benefit here and was
actively causing the bug.

## Testing
Reproduced and verified fixed on Kubuntu 26.04 (KDE Plasma), building from
source at v2.0.2. Confirmed:
- Wind tab now shows per-hour wind speed/direction
- Precipitation tab now shows per-hour precipitation bars
- Weekly now shows the 7-day forecast instead of stale hourly data
- Mouse wheel / trackpad scrolling on the hourly list still works correctly

Screenshots attached showing before/after for the Wind tab.