### PR TITLE
Improve rain icon contrast

### DIFF
--- a/data/icons/hicolor/scalable/default_icons/rain.svg
+++ b/data/icons/hicolor/scalable/default_icons/rain.svg
@@ -16,9 +16,9 @@
             <path d="M291,107c-.85,0-1.68.09-2.53.13A83.9,83.9,0,0,0,135.6,42.92,55.91,55.91,0,0,0,51,91a56.56,56.56,0,0,0,.8,9.08A60,60,0,0,0,63,219c1.35,0,2.67-.11,4-.2v.2H291a56,56,0,0,0,0-112Z" stroke="#e6effc" stroke-miterlimit="10" stroke-width="6" fill="url(#a)"/>
         </symbol>
         <symbol id="f" viewBox="0 0 129 110">
-            <path d="M8.5,56.5a8,8,0,0,1-8-8V8.5a8,8,0,0,1,16,0v40A8,8,0,0,1,8.5,56.5Z" stroke="#07306f" stroke-miterlimit="10" fill="url(#b)"/>
-            <path d="M64.5,109.5a8,8,0,0,1-8-8v-40a8,8,0,0,1,16,0v40A8,8,0,0,1,64.5,109.5Z" stroke="#07306f" stroke-miterlimit="10" fill="url(#c)"/>
-            <path d="M120.5,74.5a8,8,0,0,1-8-8v-40a8,8,0,0,1,16,0v40A8,8,0,0,1,120.5,74.5Z" stroke="#07306f" stroke-miterlimit="10" fill="url(#d)"/>
+            <path d="M8.5,56.5a8,8,0,0,1-8-8V8.5a8,8,0,0,1,16,0v40A8,8,0,0,1,8.5,56.5Z" stroke="#07306f" stroke-miterlimit="10" stroke-width="6" fill="url(#b)"/>
+            <path d="M64.5,109.5a8,8,0,0,1-8-8v-40a8,8,0,0,1,16,0v40A8,8,0,0,1,64.5,109.5Z" stroke="#07306f" stroke-miterlimit="10" stroke-width="6" fill="url(#c)"/>
+            <path d="M120.5,74.5a8,8,0,0,1-8-8v-40a8,8,0,0,1,16,0v40A8,8,0,0,1,120.5,74.5Z" stroke="#07306f" stroke-miterlimit="10" stroke-width="6" fill="url(#d)"/>
         </symbol>
     </defs>
     <use width="350" height="222" transform="translate(81 145)" xlink:href="#e"/>

--- a/data/icons/hicolor/scalable/default_icons/rain.svg
+++ b/data/icons/hicolor/scalable/default_icons/rain.svg
@@ -16,9 +16,9 @@
             <path d="M291,107c-.85,0-1.68.09-2.53.13A83.9,83.9,0,0,0,135.6,42.92,55.91,55.91,0,0,0,51,91a56.56,56.56,0,0,0,.8,9.08A60,60,0,0,0,63,219c1.35,0,2.67-.11,4-.2v.2H291a56,56,0,0,0,0-112Z" stroke="#e6effc" stroke-miterlimit="10" stroke-width="6" fill="url(#a)"/>
         </symbol>
         <symbol id="f" viewBox="0 0 129 110">
-            <path d="M8.5,56.5a8,8,0,0,1-8-8V8.5a8,8,0,0,1,16,0v40A8,8,0,0,1,8.5,56.5Z" stroke="#0a5ad4" stroke-miterlimit="10" fill="url(#b)"/>
-            <path d="M64.5,109.5a8,8,0,0,1-8-8v-40a8,8,0,0,1,16,0v40A8,8,0,0,1,64.5,109.5Z" stroke="#0a5ad4" stroke-miterlimit="10" fill="url(#c)"/>
-            <path d="M120.5,74.5a8,8,0,0,1-8-8v-40a8,8,0,0,1,16,0v40A8,8,0,0,1,120.5,74.5Z" stroke="#0a5ad4" stroke-miterlimit="10" fill="url(#d)"/>
+            <path d="M8.5,56.5a8,8,0,0,1-8-8V8.5a8,8,0,0,1,16,0v40A8,8,0,0,1,8.5,56.5Z" stroke="#07306f" stroke-miterlimit="10" fill="url(#b)"/>
+            <path d="M64.5,109.5a8,8,0,0,1-8-8v-40a8,8,0,0,1,16,0v40A8,8,0,0,1,64.5,109.5Z" stroke="#07306f" stroke-miterlimit="10" fill="url(#c)"/>
+            <path d="M120.5,74.5a8,8,0,0,1-8-8v-40a8,8,0,0,1,16,0v40A8,8,0,0,1,120.5,74.5Z" stroke="#07306f" stroke-miterlimit="10" fill="url(#d)"/>
         </symbol>
     </defs>
     <use width="350" height="222" transform="translate(81 145)" xlink:href="#e"/>

--- a/data/icons/hicolor/scalable/default_icons/raindrop.svg
+++ b/data/icons/hicolor/scalable/default_icons/raindrop.svg
@@ -6,7 +6,7 @@
             <stop offset="1" stop-color="#2477b2"/>
         </linearGradient>
         <symbol id="b" viewBox="0 0 164 245.57">
-            <path d="M82,3.57c-48.7,72-80,117-80,160.75s35.79,79.25,80,79.25,80-35.47,80-79.25S130.7,75.54,82,3.57Z" stroke="#2885c7" stroke-miterlimit="10" stroke-width="4" fill="url(#a)"/>
+            <path d="M82,3.57c-48.7,72-80,117-80,160.75s35.79,79.25,80,79.25,80-35.47,80-79.25S130.7,75.54,82,3.57Z" stroke="#07306f" stroke-miterlimit="10" stroke-width="6" fill="url(#a)"/>
         </symbol>
     </defs>
     <use width="164" height="245.57" transform="translate(174 132.43)" xlink:href="#b"/>

--- a/data/icons/hicolor/scalable/default_icons/raindrops.svg
+++ b/data/icons/hicolor/scalable/default_icons/raindrops.svg
@@ -6,7 +6,7 @@
             <stop offset="1" stop-color="#2477b2"/>
         </linearGradient>
         <symbol id="b" viewBox="0 0 164 245.57">
-            <path d="M82,3.57c-48.7,72-80,117-80,160.75s35.79,79.25,80,79.25,80-35.47,80-79.25S130.7,75.54,82,3.57Z" stroke="#2885c7" stroke-miterlimit="10" stroke-width="4" fill="url(#a)"/>
+            <path d="M82,3.57c-48.7,72-80,117-80,160.75s35.79,79.25,80,79.25,80-35.47,80-79.25S130.7,75.54,82,3.57Z" stroke="#07306f" stroke-miterlimit="10" stroke-width="6" fill="url(#a)"/>
         </symbol>
     </defs>
     <use width="164" height="245.57" transform="translate(128 133.43)" xlink:href="#b"/>


### PR DESCRIPTION
Make raindrop strokes darker and slightly thicker for better visibility (fixes #299). Updated rain.svg, raindrops.svg, raindrop.svg to use a deeper stroke color and increased stroke-width on drops. No functional changes.\n\nThis improves contrast on blue backgrounds and for users with low contrast settings.