### PR TITLE
Pressure: add inHg option

### DIFF
--- a/data/icons/hicolor/scalable/mousam_icons/rain.svg
+++ b/data/icons/hicolor/scalable/mousam_icons/rain.svg
@@ -16,9 +16,9 @@
             <path d="M291,107c-.85,0-1.68.09-2.53.13A83.9,83.9,0,0,0,135.6,42.92,55.91,55.91,0,0,0,51,91a56.56,56.56,0,0,0,.8,9.08A60,60,0,0,0,63,219c1.35,0,2.67-.11,4-.2v.2H291a56,56,0,0,0,0-112Z" stroke="#e6effc" stroke-miterlimit="10" stroke-width="6" fill="url(#a)"/>
         </symbol>
         <symbol id="f" viewBox="0 0 129 110">
-            <path d="M8.5,56.5a8,8,0,0,1-8-8V8.5a8,8,0,0,1,16,0v40A8,8,0,0,1,8.5,56.5Z" stroke="#0a5ad4" stroke-miterlimit="10" fill="url(#b)"/>
-            <path d="M64.5,109.5a8,8,0,0,1-8-8v-40a8,8,0,0,1,16,0v40A8,8,0,0,1,64.5,109.5Z" stroke="#0a5ad4" stroke-miterlimit="10" fill="url(#c)"/>
-            <path d="M120.5,74.5a8,8,0,0,1-8-8v-40a8,8,0,0,1,16,0v40A8,8,0,0,1,120.5,74.5Z" stroke="#0a5ad4" stroke-miterlimit="10" fill="url(#d)"/>
+            <path d="M8.5,56.5a8,8,0,0,1-8-8V8.5a8,8,0,0,1,16,0v40A8,8,0,0,1,8.5,56.5Z" stroke="#07306f" stroke-miterlimit="10" fill="url(#b)"/>
+            <path d="M64.5,109.5a8,8,0,0,1-8-8v-40a8,8,0,0,1,16,0v40A8,8,0,0,1,64.5,109.5Z" stroke="#07306f" stroke-miterlimit="10" fill="url(#c)"/>
+            <path d="M120.5,74.5a8,8,0,0,1-8-8v-40a8,8,0,0,1,16,0v40A8,8,0,0,1,120.5,74.5Z" stroke="#07306f" stroke-miterlimit="10" fill="url(#d)"/>
         </symbol>
     </defs>
     <use width="350" height="222" transform="translate(81 145)" xlink:href="#e"/>

--- a/data/icons/hicolor/scalable/mousam_icons/raindrop.svg
+++ b/data/icons/hicolor/scalable/mousam_icons/raindrop.svg
@@ -6,7 +6,7 @@
             <stop offset="1" stop-color="#2477b2"/>
         </linearGradient>
         <symbol id="b" viewBox="0 0 164 245.57">
-            <path d="M82,3.57c-48.7,72-80,117-80,160.75s35.79,79.25,80,79.25,80-35.47,80-79.25S130.7,75.54,82,3.57Z" stroke="#2885c7" stroke-miterlimit="10" stroke-width="4" fill="url(#a)"/>
+            <path d="M82,3.57c-48.7,72-80,117-80,160.75s35.79,79.25,80,79.25,80-35.47,80-79.25S130.7,75.54,82,3.57Z" stroke="#07306f" stroke-miterlimit="10" stroke-width="6" fill="url(#a)"/>
         </symbol>
     </defs>
     <use width="164" height="245.57" transform="translate(174 132.43)" xlink:href="#b"/>

--- a/data/icons/hicolor/scalable/mousam_icons/raindrops.svg
+++ b/data/icons/hicolor/scalable/mousam_icons/raindrops.svg
@@ -6,7 +6,7 @@
             <stop offset="1" stop-color="#2477b2"/>
         </linearGradient>
         <symbol id="b" viewBox="0 0 164 245.57">
-            <path d="M82,3.57c-48.7,72-80,117-80,160.75s35.79,79.25,80,79.25,80-35.47,80-79.25S130.7,75.54,82,3.57Z" stroke="#2885c7" stroke-miterlimit="10" stroke-width="4" fill="url(#a)"/>
+            <path d="M82,3.57c-48.7,72-80,117-80,160.75s35.79,79.25,80,79.25,80-35.47,80-79.25S130.7,75.54,82,3.57Z" stroke="#07306f" stroke-miterlimit="10" stroke-width="6" fill="url(#a)"/>
         </symbol>
     </defs>
     <use width="164" height="245.57" transform="translate(128 133.43)" xlink:href="#b"/>

--- a/data/io.github.amit9838.mousam.gschema.xml
+++ b/data/io.github.amit9838.mousam.gschema.xml
@@ -21,6 +21,11 @@
       <default>false</default>
       <summary>Use Inch for precipitation</summary>
     </key>
+	  <key name="use-inhg-for-pressure" type="b">
+	    <default>false</default>
+	    <summary>Show pressure in inches of mercury (inHg)</summary>
+	    <description>If enabled, pressure values will be displayed in inHg regardless of the global unit setting.</description>
+	  </key>
 	  <key name="use-24h-clock" type="b">
       <default>false</default>
       <summary>Use 24h hour clock</summary>

--- a/src/API_Weather.py
+++ b/src/API_Weather.py
@@ -41,7 +41,7 @@ class Weather:
             response = requests.get(url, timeout=TIMEOUT)
             response.raise_for_status()  # Raise an exception if the request was unsuccessful
             data = response.json()
-            if settings.unit == "imperial":
+            if settings.unit == "imperial" or settings.is_using_inhg_for_pressure:
                 inHg = data['current']['surface_pressure'] * HPA_TO_INHG
                 data['current']['surface_pressure'] = inHg
                 data['current_units']['surface_pressure'] = 'inHg'
@@ -80,7 +80,7 @@ class Weather:
             response = requests.get(url, timeout=TIMEOUT)
             response.raise_for_status()  # Raise an exception if the request was unsuccessful
             data = response.json()
-            if settings.unit == "imperial":
+            if settings.unit == "imperial" or settings.is_using_inhg_for_pressure:
                 for i in range(len(data['hourly']['surface_pressure'])):
                     inHg = data['hourly']['surface_pressure'][i] * HPA_TO_INHG
                     data['hourly']['surface_pressure'][i] = inHg

--- a/src/CORE_weatherData.py
+++ b/src/CORE_weatherData.py
@@ -175,7 +175,7 @@ class WeatherDataManager(GObject.Object):
     @staticmethod
     def classify_presssure_level(p):
         low, normal = 940, 1010
-        if settings.unit == "imperial":
+        if settings.unit == "imperial" or settings.is_using_inhg_for_pressure:
             low, normal = low * HPA_TO_INHG, normal * HPA_TO_INHG
         if p < low: return C_("pressure", "Low")
         if p <= normal: return C_("pressure", "Normal")

--- a/src/settings.py
+++ b/src/settings.py
@@ -60,6 +60,14 @@ class Settings:
         self.settings.set_boolean("use-inch-for-prec", value)
 
     @property
+    def is_using_inhg_for_pressure(self):
+        return self.settings.get_boolean("use-inhg-for-pressure")
+
+    @is_using_inhg_for_pressure.setter
+    def is_using_inhg_for_pressure(self, value):
+        self.settings.set_boolean("use-inhg-for-pressure", value)
+
+    @property
     def is_using_24h_clock(self):
         return self.settings.get_boolean("use-24h-clock")
 

--- a/src/windowPreferences.py
+++ b/src/windowPreferences.py
@@ -204,6 +204,21 @@ class WeatherPreferences(Adw.PreferencesWindow):
 
         group.add(prec_row)
 
+        # Pressure unit (hPa/inHg)
+        pres_row = Adw.ActionRow(
+            title=_("Pressure in inHg"),
+            subtitle=_("Show pressure in inches of mercury (inHg) regardless of unit system"),
+            icon_name="gauge-symbolic",
+            activatable=True,
+        )
+        pres_switch = Gtk.Switch(valign=Gtk.Align.CENTER)
+        pres_switch.set_active(settings.is_using_inhg_for_pressure)
+        pres_switch.connect("state-set", self._on_pressure_unit_toggled)
+        pres_row.add_suffix(pres_switch)
+        self._pressure_switch = pres_switch
+
+        group.add(pres_row)
+
     def _add_reset_row(self, parent: Adw.PreferencesPage) -> None:
         data_group = Adw.PreferencesGroup()
         data_group.set_title(_("Data Management"))
@@ -307,6 +322,10 @@ class WeatherPreferences(Adw.PreferencesWindow):
 
     def _on_precip_unit_toggled(self, switch: Gtk.Switch, state: bool) -> None:
         settings.is_using_inch_for_prec = state
+        self._start_refresh_thread()
+
+    def _on_pressure_unit_toggled(self, switch: Gtk.Switch, state: bool) -> None:
+        settings.is_using_inhg_for_pressure = state
         self._start_refresh_thread()
 
     def _on_notifications_toggled(self, switch: Gtk.Switch, state: bool) -> None:


### PR DESCRIPTION
Add a preference to show pressure in inches of mercury (inHg) regardless of the global unit setting. Updates:

- schema: add use-inhg-for-pressure key
- settings: expose is_using_inhg_for_pressure
- API_Weather: convert pressure to inHg when the new setting is enabled
- CORE_weatherData: classification thresholds respect inHg
- Preferences UI: add toggle to enable pressure in inHg

Fixes #172.