### PR TITLE
fix: fix and complete Spanish (es_ES) translations

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -9,7 +9,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-08-05 12:03-0300\n"
 "PO-Revision-Date: 2023-06-18 11:17+0300\n"
-"Last-Translator: Radical4ever\n"
+"Last-Translator: capitantrueno\n"
 "Language-Team: \n"
 "Language: es_ES\n"
 "MIME-Version: 1.0\n"
@@ -25,20 +25,19 @@ msgstr ""
 #: data/io.github.amit9838.mousam.desktop.in:5
 #: data/io.github.amit9838.mousam.appdata.xml.in:7 src/windowAbout.py:17
 msgid "Weather at a glance"
-msgstr "Un vistazo del Tiempo"
+msgstr "El tiempo de un vistazo"
 
 #: data/io.github.amit9838.mousam.desktop.in:10
 msgid "Weather;Mousam;Rain;Cloud;Forecast;GTK4;Python;temperature;"
-msgstr ""
+msgstr "Tiempo;Meteorología;Mousam;Lluvia;Nube;Previsión;GTK4;Python;temperatura;"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:9
-#, fuzzy
 msgid "Current Weather conditions and forecasts."
-msgstr "Condiciones actuales y previsión del Tiempo"
+msgstr "Condiciones meteorológicas actuales y previsiones."
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:10
 msgid "Features:"
-msgstr "Caracteristicas:"
+msgstr "Características:"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:12
 msgid ""
@@ -51,67 +50,66 @@ msgstr ""
 #: data/io.github.amit9838.mousam.appdata.xml.in:13
 msgid "Comprehensive Air Quality Index and air pollutants data"
 msgstr ""
+"Índice de calidad del aire completo y datos de contaminantes atmosféricos"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:14
-#, fuzzy
 msgid "Also provides tomorrow and 7-day forecasts"
-msgstr "Tambien provee la previsión de mañana y de los 7 días siguientes"
+msgstr "También ofrece previsiones para mañana y para los próximos 7 días"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:15
 msgid "See conditions in metric or imperial systems"
 msgstr "Muestra las condiciones en sistema métrico o imperial"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:21
-#, fuzzy
 msgid "Clear Sky - day"
 msgstr "Cielo despejado - día"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:25
 msgid "Snowfall - day"
-msgstr ""
+msgstr "Nevada - día"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:15
-#, fuzzy
 msgid "Clear Sky - night"
 msgstr "Cielo despejado - noche"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:16
 msgid "Visual graphs for sun and moon positions and day/night cycles"
 msgstr ""
+"Gráficos visuales de las posiciones del sol y la luna y de los ciclos día/"
+"noche"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:17
 msgid "Hourly temperature, wind direction and precipitation tracking"
 msgstr ""
+"Seguimiento por horas de la temperatura, la dirección del viento y la "
+"precipitación"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:18
-#, fuzzy
 msgid "Dynamic background styling that adapts to weather conditions"
 msgstr ""
-"Cambios en segundo plano basados en las condiciones actuales del clima "
-"(Reinicio requerido)"
+"Estilo de fondo dinámico que se adapta a las condiciones meteorológicas"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:19
 msgid "System notifications for weather updates with configurable preferences"
 msgstr ""
+"Notificaciones del sistema para las actualizaciones del tiempo con "
+"preferencias configurables"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:20
-#, fuzzy
 msgid "Support for both metric and imperial measurement systems"
-msgstr "Muestra las condiciones en sistema metrico o imperial"
+msgstr "Compatible con los sistemas de medida métrico e imperial"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:26
 msgid "Main dashboard showing current weather and hourly forecast"
-msgstr ""
+msgstr "Panel principal con el tiempo actual y la previsión por horas"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:30
-#, fuzzy
 msgid "Detailed weather conditions during rain"
-msgstr "Condiciones actuales y prevision del Clima"
+msgstr "Condiciones meteorológicas detalladas durante la lluvia"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:34
-#, fuzzy
 msgid "Night mode view"
-msgstr "Modo claro"
+msgstr "Vista en modo nocturno"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:43
 msgid "Amit Chaudhary"
@@ -119,14 +117,13 @@ msgstr ""
 
 #: data/io.github.amit9838.mousam.gschema.xml:7
 msgid "List of cities and their coordinates."
-msgstr "Lista de ciudades y sus coordenandas."
+msgstr "Lista de ciudades y sus coordenadas."
 
 #: data/io.github.amit9838.mousam.gschema.xml:8
 msgid ""
 "Stores locations added by user in json stringified string format in string"
 msgstr ""
-"Guarda las localizaciones añadidas por el usuario en un archivo json "
-"encadenado en formato string"
+"Guarda las ubicaciones añadidas por el usuario en formato de cadena JSON"
 
 #: data/io.github.amit9838.mousam.gschema.xml:12
 msgid "Selected city"
@@ -134,18 +131,18 @@ msgstr "Ciudad seleccionada"
 
 #: data/io.github.amit9838.mousam.gschema.xml:13
 msgid "Selected city cords"
-msgstr "Seleccionar coordenadas de la ciudad"
+msgstr "Coordenadas de la ciudad seleccionada"
 
 #: data/io.github.amit9838.mousam.gschema.xml:17
 msgid "Use Gradient Background"
-msgstr "Usar Fondo Gradiente"
+msgstr "Usar fondo degradado"
 
 #: data/io.github.amit9838.mousam.gschema.xml:18
 msgid ""
 "Apply gradient background on main window corresponding to weather condition"
 msgstr ""
-"Aplicar fondo gradiente en la ventana principal correspondiente a las "
-"condiciones del tiempo"
+"Aplicar un fondo degradado en la ventana principal según las condiciones "
+"meteorológicas"
 
 #: data/io.github.amit9838.mousam.gschema.xml:22
 msgid "Use Inch for precipitation"
@@ -153,7 +150,7 @@ msgstr "Usar pulgadas para la precipitación"
 
 #: data/io.github.amit9838.mousam.gschema.xml:26
 msgid "Use 24h hour clock"
-msgstr "Usar reloj 24hrs"
+msgstr "Usar reloj de 24 horas"
 
 #: data/io.github.amit9838.mousam.gschema.xml:30
 msgid "Main window width"
@@ -165,78 +162,80 @@ msgstr "Alto de la ventana principal"
 
 #: data/io.github.amit9838.mousam.gschema.xml:38
 msgid "Launch the app in maximized mode."
-msgstr "Iniciar la app en modo pantalla completa."
+msgstr "Iniciar la aplicación maximizada."
 
 #: data/io.github.amit9838.mousam.gschema.xml:42
 msgid "Auto-refresh interval in minutes"
-msgstr ""
+msgstr "Intervalo de actualización automática en minutos"
 
 #: data/io.github.amit9838.mousam.gschema.xml:43
 msgid "Interval for automatic weather refresh. 0 means disabled."
 msgstr ""
+"Intervalo de actualización automática del tiempo. 0 significa desactivado."
 
 #: data/io.github.amit9838.mousam.gschema.xml:47
-#, fuzzy
 msgid "Measurement system to use - metric,imperial"
-msgstr "Sistemas de medición a usar - métrico,imperial"
+msgstr "Sistema de medida que se usará: métrico, imperial"
 
 #: data/io.github.amit9838.mousam.gschema.xml:48
 msgid "metric(km, °C), imperial(mile, °F)"
-msgstr "métrico(km, °C), imperial(milla, °F)"
+msgstr "métrico (km, °C), imperial (milla, °F)"
 
 #: data/io.github.amit9838.mousam.gschema.xml:52
 msgid "Show weather update notifications"
-msgstr ""
+msgstr "Mostrar notificaciones de actualización del tiempo"
 
 #: data/io.github.amit9838.mousam.gschema.xml:53
 msgid "Show a notification when weather data is updated."
-msgstr ""
+msgstr "Muestra una notificación cuando se actualizan los datos meteorológicos."
 
 #: data/io.github.amit9838.mousam.gschema.xml:57
 msgid "Enable debug mode"
-msgstr ""
+msgstr "Activar el modo de depuración"
 
 #: data/io.github.amit9838.mousam.gschema.xml:58
 msgid "Enables detailed logging and console output."
-msgstr ""
+msgstr "Activa el registro detallado y la salida por consola."
 
 #: data/io.github.amit9838.mousam.gschema.xml:62
 msgid "Icon theme"
-msgstr ""
+msgstr "Tema de iconos"
 
 #: data/io.github.amit9838.mousam.gschema.xml:63
 msgid ""
 "Weather icon set: \"default\" (mousam default icons) or \"material\" (Google "
 "material design icons)"
 msgstr ""
+"Conjunto de iconos meteorológicos: «default» (iconos predeterminados de "
+"Mousam) o «material» (iconos de Google Material Design)"
 
 #: src/configs.py:33
 msgid "Off"
-msgstr ""
+msgstr "Desactivado"
 
 #: src/configs.py:34
 msgid "Every 15 minutes"
-msgstr ""
+msgstr "Cada 15 minutos"
 
 #: src/configs.py:35
 msgid "Every 30 minutes"
-msgstr ""
+msgstr "Cada 30 minutos"
 
 #: src/configs.py:36
 msgid "Every hour"
-msgstr ""
+msgstr "Cada hora"
 
 #: src/configs.py:37
 msgid "Every 2 hours"
-msgstr ""
+msgstr "Cada 2 horas"
 
 #: src/CORE_GTKUtils.py:66
 msgid "Unknown"
-msgstr ""
+msgstr "Desconocido"
 
 #: src/CORE_Helpers.py:106 src/CORE_Helpers.py:109
 msgid "Unknown City"
-msgstr ""
+msgstr "Ciudad desconocida"
 
 #: src/CORE_Icons.py:261
 msgid "Clear sky"
@@ -252,7 +251,7 @@ msgstr "Parcialmente nublado"
 
 #: src/CORE_Icons.py:264
 msgid "Overcast"
-msgstr "Nublado"
+msgstr "Cubierto"
 
 #: src/CORE_Icons.py:265
 msgid "Fog"
@@ -264,79 +263,79 @@ msgstr "Neblina"
 
 #: src/CORE_Icons.py:267
 msgid "Light Drizzle"
-msgstr "Ligera Llovizna"
+msgstr "Llovizna débil"
 
 #: src/CORE_Icons.py:268
 msgid "Moderate Drizzle"
-msgstr "Moderada Llovizna"
+msgstr "Llovizna moderada"
 
 #: src/CORE_Icons.py:269
 msgid "Heavy Intensity Drizzle"
-msgstr "Fuerte Llovizna"
+msgstr "Llovizna intensa"
 
 #: src/CORE_Icons.py:270
 msgid "Light Freezing Drizzle"
-msgstr "Ligera Llovizna Helada"
+msgstr "Llovizna helada débil"
 
 #: src/CORE_Icons.py:271
 msgid "Heavy Freezing Drizzle"
-msgstr "Fuerte Lloviza Helada"
+msgstr "Llovizna helada intensa"
 
 #: src/CORE_Icons.py:272
 msgid "Light Rain"
-msgstr "Ligeras Lluvias"
+msgstr "Lluvia débil"
 
 #: src/CORE_Icons.py:273
 msgid "Moderate Rain"
-msgstr "Lluvia Moderada"
+msgstr "Lluvia moderada"
 
 #: src/CORE_Icons.py:274
 msgid "Heavy Rain"
-msgstr "Lluvia Fuerte"
+msgstr "Lluvia fuerte"
 
 #: src/CORE_Icons.py:275
 msgid "Light Freezing Rain"
-msgstr "Ligera Lluvia Helada"
+msgstr "Lluvia helada débil"
 
 #: src/CORE_Icons.py:276
 msgid "Heavy Freezing Rain"
-msgstr "Fuerte Lluvia Helada"
+msgstr "Lluvia helada intensa"
 
 #: src/CORE_Icons.py:277
 msgid "Light Snow Fall"
-msgstr "Ligera Caida de Nieve"
+msgstr "Nevada débil"
 
 #: src/CORE_Icons.py:278
 msgid "Moderate Snow Fall"
-msgstr "Moderada Caida de Nieve"
+msgstr "Nevada moderada"
 
 #: src/CORE_Icons.py:279
 msgid "Heavy Snow Fall"
-msgstr "Fuerte Caida de Nieve"
+msgstr "Nevada intensa"
 
 #: src/CORE_Icons.py:280
 msgid "Snow grains"
-msgstr "Granizo"
+msgstr "Granos de nieve"
 
 #: src/CORE_Icons.py:281
 msgid "Light Rain Showers"
-msgstr "Ligera Lluvias"
+msgstr "Chubascos débiles"
 
 #: src/CORE_Icons.py:282
 msgid "Moderate Rain Showers"
-msgstr "Moderadas Lluvias"
+msgstr "Chubascos moderados"
 
 #: src/CORE_Icons.py:283
 msgid "Heavy Rain Showers"
-msgstr "Fuertes Lluvias"
+msgstr "Chubascos fuertes"
 
 #: src/CORE_Icons.py:284
 msgid "Light Snow Showers"
-msgstr "Ligera Nevada"
+msgstr "Chubascos de nieve débiles"
 
 #: src/CORE_Icons.py:285
 msgid "Heavy Snow Showers "
-msgstr "Fuerte Nevada"
+msgstr "Chubascos de nieve intensos"
 
 #: src/CORE_Icons.py:286
 msgid "Thunderstorm"
@@ -344,19 +343,19 @@ msgstr "Tormenta"
 
 #: src/CORE_Icons.py:287
 msgid "Thunderstorm with Hail"
-msgstr "Tormenta con Granizo"
+msgstr "Tormenta con granizo"
 
 #: src/CORE_weatherData.py:154
 msgid "Good"
-msgstr "Bien"
+msgstr "Buena"
 
 #: src/CORE_weatherData.py:155
 msgid "Moderate"
-msgstr "Moderado"
+msgstr "Moderada"
 
 #: src/CORE_weatherData.py:156
 msgid "Poor"
-msgstr "Pobre"
+msgstr "Mala"
 
 #: src/CORE_weatherData.py:157
 msgid "Unhealthy"
@@ -364,11 +363,11 @@ msgstr "Insalubre"
 
 #: src/CORE_weatherData.py:158
 msgid "Severe"
-msgstr "Severo"
+msgstr "Muy mala"
 
 #: src/CORE_weatherData.py:159
 msgid "Hazardous"
-msgstr "Peligroso"
+msgstr "Peligrosa"
 
 #: src/CORE_weatherData.py:163
 msgctxt "uvindex"
@@ -388,7 +387,7 @@ msgstr "Alto"
 #: src/CORE_weatherData.py:166
 msgctxt "uvindex"
 msgid "Very High"
-msgstr "Muy Alto"
+msgstr "Muy alto"
 
 #: src/CORE_weatherData.py:167
 msgctxt "uvindex"
@@ -398,22 +397,22 @@ msgstr "Extremo"
 #: src/CORE_weatherData.py:171
 msgctxt "humidity"
 msgid "Low"
-msgstr "Bajo"
+msgstr "Baja"
 
 #: src/CORE_weatherData.py:172
 msgctxt "humidity"
 msgid "Moderate"
-msgstr "Moderado"
+msgstr "Moderada"
 
 #: src/CORE_weatherData.py:173
 msgctxt "humidity"
 msgid "High"
-msgstr "Alto"
+msgstr "Alta"
 
 #: src/CORE_weatherData.py:180
 msgctxt "pressure"
 msgid "Low"
-msgstr "Bajo"
+msgstr "Baja"
 
 #: src/CORE_weatherData.py:181
 msgctxt "pressure"
@@ -423,15 +422,15 @@ msgstr "Normal"
 #: src/CORE_weatherData.py:182
 msgctxt "pressure"
 msgid "High"
-msgstr "Alto"
+msgstr "Alta"
 
 #: src/CORE_weatherData.py:186
 msgid "Calm"
-msgstr "Calmado"
+msgstr "En calma"
 
 #: src/CORE_weatherData.py:187
 msgid "Light"
-msgstr "Ligero"
+msgstr "Flojo"
 
 #: src/CORE_weatherData.py:188
 msgctxt "wind"
@@ -457,15 +456,15 @@ msgstr "millas"
 
 #: src/UI_CardAirPollution.py:93
 msgid "Air Pollution"
-msgstr "Contaminación del Aire"
+msgstr "Contaminación del aire"
 
 #: src/UI_CardAirPollution.py:105
 msgid "Air Quality Components"
-msgstr ""
+msgstr "Componentes de la calidad del aire"
 
 #: src/UI_CardAirPollution.py:153
 msgid "Air Quality Index"
-msgstr ""
+msgstr "Índice de calidad del aire"
 
 #: src/UI_CardAirPollution.py:180
 msgid "PM2.5"
@@ -497,7 +496,7 @@ msgstr ""
 
 #: src/UI_CardAirPollution.py:187
 msgid "Dust"
-msgstr ""
+msgstr "Polvo"
 
 #: src/UI_CardAirPollution.py:188
 msgid "NH₃"
@@ -508,45 +507,45 @@ msgid "CH₄"
 msgstr ""
 
 #: src/UI_CardAirPollution.py:190
-#, fuzzy
 msgid "Alder Pollen"
-msgstr "Contaminación del Aire"
+msgstr "Polen de aliso"
 
 #: src/UI_CardAirPollution.py:191
-#, fuzzy
 msgid "Birch Pollen"
-msgstr "Contaminación del Aire"
+msgstr "Polen de abedul"
 
 #: src/UI_CardAirPollution.py:192
 msgid "Grass Pollen"
-msgstr ""
+msgstr "Polen de gramíneas"
 
 #: src/UI_CardAirPollution.py:193
 msgid "Mugwort Pollen"
-msgstr ""
+msgstr "Polen de artemisa"
 
 #: src/UI_CardAirPollution.py:194
 msgid "Olive Pollen"
-msgstr ""
+msgstr "Polen de olivo"
 
 #: src/UI_CardAirPollution.py:195
 msgid "Ragweed Pollen"
-msgstr ""
+msgstr "Polen de ambrosía"
 
 #: src/UI_CardAirPollution.py:215
 #, python-brace-format
 msgid "Safe limit: ≤ {0} {1}"
-msgstr ""
+msgstr "Límite seguro: ≤ {0} {1}"
 
 #: src/UI_CardAirPollution.py:243
 msgid ""
 "AQI: US EPA Standard\n"
 "Pollutant limits: WHO Guidelines (2021)"
 msgstr ""
+"ICA: estándar de la US EPA\n"
+"Límites de contaminantes: directrices de la OMS (2021)"
 
 #: src/UI_CardDayNight.py:76
 msgid "Sunrise & Sunset"
-msgstr "Amanecer & Atardecer"
+msgstr "Amanecer y atardecer"
 
 #: src/UI_CardDayNight.py:87
 msgid "Sunrise"
@@ -563,12 +562,11 @@ msgstr "Viento"
 
 #: src/UI_HourlyDetails.py:51
 msgid "Hourly"
-msgstr "Por Hora"
+msgstr "Por hora"
 
 #: src/UI_HourlyDetails.py:53
-#, fuzzy
 msgid "Precipitation"
-msgstr "Mostrar precipitacion en pulgadas"
+msgstr "Precipitación"
 
 #: src/UI_CardSquare.py:31
 msgid "Pressure"
@@ -612,41 +610,40 @@ msgstr "Oeste"
 
 #: src/UI_CardSquare.py:215
 msgid "Northwest"
-msgstr "Noreste"
+msgstr "Noroeste"
 
 #: src/UI_CompactWeather.py:71 src/UI_CompactWeather.py:89 src/mousam.py:345
 msgid "No Internet"
-msgstr "No hay Internet"
+msgstr "Sin conexión a Internet"
 
 #: src/UI_CompactWeather.py:289
 msgid "Hum."
-msgstr ""
+msgstr "Hum."
 
 #: src/UI_CompactWeather.py:293
-#, fuzzy
 msgid "Pres."
-msgstr "Presión"
+msgstr "Pres."
 
 #: src/UI_CompactWeather.py:297
 msgid "AQI"
-msgstr ""
+msgstr "ICA"
 
 #: src/UI_CompactWeather.py:350
 msgid "Mousam Compact"
-msgstr ""
+msgstr "Mousam Compacto"
 
 #: src/UI_CompDrawDayNight.py:154
 msgid "Day"
-msgstr ""
+msgstr "Día"
 
 #: src/UI_CompDrawDayNight.py:154
 msgid "Night"
 msgstr "Noche"
 
 #: src/UI_CurrentCond.py:96
-#, fuzzy, python-brace-format
+#, python-brace-format
 msgid "Feels like • <b> {0} {1}</b>"
-msgstr "Se siente como • <b> {0} {1}</b>"
+msgstr "Sensación térmica • <b> {0} {1}</b>"
 
 #: src/UI_Forecast.py:139 src/UI_Forecast.py:318
 msgid "Tomorrow"
@@ -661,22 +658,19 @@ msgid "Today"
 msgstr "Hoy"
 
 #: src/UI_HourlyDetails.py:151
-#, fuzzy
 msgctxt "temperature"
 msgid "Day Max •"
-msgstr "Máxima de hoy"
+msgstr "Máx. del día •"
 
 #: src/UI_HourlyDetails.py:157
-#, fuzzy
 msgctxt "wind"
 msgid "Day High •"
-msgstr "Vientos"
+msgstr "Máx. del día •"
 
 #: src/UI_HourlyDetails.py:168
-#, fuzzy
 msgctxt "precipitation"
 msgid "Day High •"
-msgstr "Precipitación Máxima"
+msgstr "Máx. del día •"
 
 #: src/UI_HourlyDetails.py:243
 msgid "Now"
@@ -684,44 +678,43 @@ msgstr "Ahora"
 
 #: src/UI_HourlyDetails.py:285
 msgid "No precipitation today !"
-msgstr "No hay precipitaciones para hoy !"
+msgstr "¡Hoy no hay precipitaciones!"
 
 #: src/UI_HourlyDetails.py:286
 msgid "No precipitation expected today!"
-msgstr "No hay precipitaciones para hoy!"
+msgstr "¡No se esperan precipitaciones para hoy!"
 
 #: src/UI_HourlyDetails.py:287
 msgid "Anticipate a precipitation-free day !"
-msgstr "Anticipate un día sin precipitaciones !"
+msgstr "Prepárate para un día sin precipitaciones."
 
 #: src/UI_HourlyDetails.py:288
 msgid "Enjoy a rain-free day today!"
-msgstr "Disfruta un día sin lluvias!"
+msgstr "¡Disfruta hoy de un día sin lluvia!"
 
 #: src/UI_HourlyDetails.py:289
 msgid "Umbrella status: resting. No precipitation in sight !"
-msgstr "Estado del paraguas: descansando. No hay precipitaciones a la vista !"
+msgstr "Estado del paraguas: en reposo. ¡No hay precipitaciones a la vista!"
 
 #: src/UI_HourlyDetails.py:290
 msgid "No rain in sight today!"
-msgstr "No hay lluvia a la vista!"
+msgstr "¡Hoy no se prevé lluvia!"
 
 #: src/mousam.py:83
 msgid "Debug Mode Enabled"
-msgstr ""
+msgstr "Modo de depuración activado"
 
 #: src/mousam.py:84
 msgid "View Logs"
-msgstr ""
+msgstr "Ver registros"
 
 #: src/mousam.py:88
 msgid "Debug Mode Disabled"
-msgstr ""
+msgstr "Modo de depuración desactivado"
 
 #: src/mousam.py:125
-#, fuzzy
 msgid "Refresh weather"
-msgstr "Actualizar Tiempo"
+msgstr "Actualizar el tiempo"
 
 #: src/mousam.py:140 src/windowLocations.py:135 src/shortcutsDialog.ui:39
 msgid "Locations"
@@ -729,7 +722,7 @@ msgstr "Ubicaciones"
 
 #: src/mousam.py:146
 msgid "Compact Mode"
-msgstr ""
+msgstr "Modo compacto"
 
 #: src/mousam.py:172 src/shortcutsDialog.ui:45
 msgid "Preferences"
@@ -737,7 +730,7 @@ msgstr "Preferencias"
 
 #: src/mousam.py:173 src/shortcutsDialog.ui:63
 msgid "Keyboard Shortcuts"
-msgstr "Atajos de Teclado"
+msgstr "Atajos de teclado"
 
 #: src/mousam.py:174
 msgid "About Mousam"
@@ -748,94 +741,86 @@ msgid "Quit"
 msgstr "Salir"
 
 #: src/mousam.py:279
-#, fuzzy
 msgid "Direction"
 msgstr "Dirección"
 
 #: src/mousam.py:293
 msgid "Dewpoint"
-msgstr "Punto de Rocío"
+msgstr "Punto de rocío"
 
 #: src/mousam.py:345
 msgid "Please check your connection."
-msgstr ""
+msgstr "Comprueba tu conexión."
 
 #: src/mousam.py:350
 msgid "Fetch Error"
-msgstr ""
+msgstr "Error al obtener los datos"
 
 #: src/mousam.py:364
 msgid "Getting Weather Data"
-msgstr "Obteniendo Datos del Tiempo"
+msgstr "Obteniendo datos meteorológicos"
 
 #: src/mousam.py:371
-#, fuzzy
 msgid "Welcome to Mousam"
-msgstr "Acerca de Mousam"
+msgstr "Te damos la bienvenida a Mousam"
 
 #: src/mousam.py:372
-#, fuzzy
 msgid "Add a location to get started."
-msgstr "Añade mas ubicaciones para elimarla!"
+msgstr "Añade una ubicación para empezar."
 
 #: src/mousam.py:373
-#, fuzzy
 msgid "Add Location"
-msgstr "Añadir Nueva Ubicación"
+msgstr "Añadir ubicación"
 
 #: src/mousam.py:387
 msgid "Retry"
-msgstr ""
+msgstr "Reintentar"
 
 #: src/windowAbout.py:20
 msgid "Copyright © 2024 Mousam Developers"
-msgstr ""
+msgstr "Copyright © 2024 Desarrolladores de Mousam"
 
 #: src/windowAbout.py:24
-#, fuzzy
 msgid "translator-credits"
-msgstr "creditos_traduccion"
+msgstr ""
+"Radical4ever\n"
+"Mario Rodrigo Solaz"
 
 #: src/windowLocations.py:54
 msgid "Add New Location"
-msgstr "Añadir Nueva Ubicación"
+msgstr "Añadir nueva ubicación"
 
 #: src/windowLocations.py:70
 msgid "Search for a city"
-msgstr "Buscar una Ciudad"
+msgstr "Buscar una ciudad"
 
 #: src/windowLocations.py:84
-#, fuzzy
 msgid "Search for your city..."
-msgstr "Buscar una Ciudad"
+msgstr "Busca tu ciudad…"
 
 #: src/windowLocations.py:106
-#, fuzzy
 msgid "No cities found."
-msgstr "No se encontraron resultados"
+msgstr "No se ha encontrado ninguna ciudad."
 
 #: src/windowLocations.py:144
-#, fuzzy
 msgid "Saved Locations"
-msgstr "Ubicaciones"
+msgstr "Ubicaciones guardadas"
 
 #: src/windowLocations.py:146
 msgid "Add"
 msgstr "Añadir"
 
 #: src/windowLocations.py:201
-#, fuzzy
 msgid "Location already exists"
-msgstr "Ubicación ya agregada!"
+msgstr "La ubicación ya existe"
 
 #: src/windowLocations.py:223
 msgid "Switched to {}"
 msgstr "Cambiado a {}"
 
 #: src/windowPreferences.py:30
-#, fuzzy
 msgid "Weather Preferences"
-msgstr "Preferencias"
+msgstr "Preferencias meteorológicas"
 
 #: src/windowPreferences.py:44
 msgid "Appearance"
@@ -847,19 +832,19 @@ msgstr "Avanzado"
 
 #: src/windowPreferences.py:64
 msgid "Logging &amp; Debugging"
-msgstr ""
+msgstr "Registro y depuración"
 
 #: src/windowPreferences.py:74
 msgid "Icon Theme"
-msgstr ""
+msgstr "Tema de iconos"
 
 #: src/windowPreferences.py:75
 msgid "Choose between Default and Material design weather icons"
-msgstr ""
+msgstr "Elige entre los iconos meteorológicos Default y Material Design"
 
 #: src/windowPreferences.py:85
 msgid "Default"
-msgstr ""
+msgstr "Predeterminado"
 
 #: src/windowPreferences.py:90
 msgid "Material"
@@ -867,26 +852,24 @@ msgstr ""
 
 #: src/windowPreferences.py:105
 msgid "Dynamic Background"
-msgstr "Fondo Dinámico"
+msgstr "Fondo dinámico"
 
 #: src/windowPreferences.py:107
-#, fuzzy
 msgid "App background changes based on current weather conditions"
-msgstr "Cambios en el fondo basados en las condiciones actuales "
-"(Reinicio requerido)"
+msgstr ""
+"El fondo de la aplicación cambia según las condiciones meteorológicas actuales"
 
 #: src/windowPreferences.py:121
 msgid "Time Format"
-msgstr "Formato de Tiempo"
+msgstr "Formato de hora"
 
 #: src/windowPreferences.py:122
-#, fuzzy
 msgid "Weather time format"
-msgstr "Formato de tiempo (Reinicio requerido)"
+msgstr "Formato de hora del tiempo"
 
 #: src/windowPreferences.py:132
 msgid "24 Hour"
-msgstr "24 Horas"
+msgstr "24 horas"
 
 #: src/windowPreferences.py:137
 msgid "AM / PM"
@@ -894,32 +877,33 @@ msgstr "AM / PM"
 
 #: src/windowPreferences.py:153
 msgid "Auto Refresh"
-msgstr "Recargar automáticamente"
+msgstr "Actualización automática"
 
 #: src/windowPreferences.py:154
 msgid "Automatically refresh weather data at a set interval"
-msgstr "Automáticamente recargar datos del tiempo en un intervalo de tiempo"
+msgstr ""
+"Actualiza automáticamente los datos meteorológicos en un intervalo definido"
 
 #: src/windowPreferences.py:171
-#, fuzzy
 msgid "Show Notifications"
-msgstr "Mostrar Notificaciones"
+msgstr "Mostrar notificaciones"
 
 #: src/windowPreferences.py:172
 msgid "Show notification when weather is refreshed automatically"
-msgstr ""
+msgstr "Muestra una notificación cuando el tiempo se actualiza automáticamente"
 
 #: src/windowPreferences.py:187
 msgid "Units &amp; Measurements"
-msgstr "Unidades &amp; Medidas"
+msgstr "Unidades y medidas"
 
 #: src/windowPreferences.py:192
 msgid "System Unit"
-msgstr "Sistema Métrico"
+msgstr "Sistema de unidades"
 
 #: src/windowPreferences.py:193
 msgid "Metric (C, mm, km/h) or Imperial (F, inches, mph) [restart required]"
-msgstr "Métrico (C, mm, km/h) o Imperial (F, pulgadas, mpg) [requiere reiniciar]"
+msgstr ""
+"Métrico (C, mm, km/h) o Imperial (F, pulgadas, mph) [requiere reiniciar]"
 
 #: src/windowPreferences.py:204
 msgid "Metric"
@@ -930,30 +914,28 @@ msgid "Imperial"
 msgstr "Imperial"
 
 #: src/windowPreferences.py:227
-#, fuzzy
 msgid "Precipitation in inches"
-msgstr "Mostrar precipitación en pulgadas"
+msgstr "Precipitación en pulgadas"
 
 #: src/windowPreferences.py:228
-#, fuzzy
 msgid "This option works better in heavy precipitation"
-msgstr "Esta opción funciona mejor con precipitación fuerte (Reinicio requerido)"
+msgstr "Esta opción funciona mejor con precipitación intensa"
 
 #: src/windowPreferences.py:242
 msgid "Data Management"
-msgstr ""
+msgstr "Gestión de datos"
 
 #: src/windowPreferences.py:247
 msgid "Reset to Default"
-msgstr "Restaurar valores por defecto"
+msgstr "Restablecer los valores predeterminados"
 
 #: src/windowPreferences.py:248
 msgid "Clear all preferences and restore default values"
-msgstr "Borra todos los ajustes y restaura los valores por defecto"
+msgstr "Borra todas las preferencias y restaura los valores predeterminados"
 
 #: src/windowPreferences.py:251
 msgid "Reset…"
-msgstr "Restaurar…"
+msgstr "Restablecer…"
 
 #: src/windowPreferences.py:260
 msgid "Debug Mode"
@@ -969,7 +951,7 @@ msgstr "Abrir carpeta de registros"
 
 #: src/windowPreferences.py:275
 msgid "Access the application log files"
-msgstr ""
+msgstr "Accede a los archivos de registro de la aplicación"
 
 #: src/windowPreferences.py:288
 msgid "Clear Log File"
@@ -977,11 +959,11 @@ msgstr "Limpiar archivo de registros"
 
 #: src/windowPreferences.py:289
 msgid "Delete all contents of the current log file"
-msgstr "Borra todos los contenidos del archivo de registros"
+msgstr "Borra todo el contenido del archivo de registro actual"
 
 #: src/windowPreferences.py:340
 msgid "Icon theme changed to {}"
-msgstr ""
+msgstr "Tema de iconos cambiado a {}"
 
 #: src/windowPreferences.py:349
 msgid "Switched to - {}"
@@ -989,41 +971,43 @@ msgstr "Cambiado a - {}"
 
 #: src/windowPreferences.py:368
 msgid "Logs cleared"
-msgstr ""
+msgstr "Registros borrados"
 
 #: src/windowPreferences.py:370
 msgid "Failed to clear logs"
-msgstr ""
+msgstr "No se han podido borrar los registros"
 
 #: src/windowPreferences.py:381
 msgid "Auto refresh disabled"
-msgstr ""
+msgstr "Actualización automática desactivada"
 
 #: src/windowPreferences.py:383
 msgid "Auto refresh every {} min"
-msgstr ""
+msgstr "Actualización automática cada {} min"
 
 #: src/windowPreferences.py:390
 msgid "Reset Settings?"
-msgstr ""
+msgstr "¿Restablecer los ajustes?"
 
 #: src/windowPreferences.py:392
 msgid ""
 "This will restore all settings to default and will clear your saved cities. "
 "This action cannot be undone."
 msgstr ""
+"Esto restaurará todos los ajustes a sus valores predeterminados y borrará las "
+"ciudades guardadas. Esta acción no se puede deshacer."
 
 #: src/windowPreferences.py:396
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #: src/windowPreferences.py:397
 msgid "Reset"
-msgstr ""
+msgstr "Restablecer"
 
 #: src/windowPreferences.py:438
 msgid "Preferences have been reset"
-msgstr ""
+msgstr "Se han restablecido las preferencias"
 
 #: src/shortcutsDialog.ui:29
 msgid "General"
@@ -1031,11 +1015,11 @@ msgstr "General"
 
 #: src/shortcutsDialog.ui:33
 msgid "Refresh Weather"
-msgstr "Actualizar Tiempo"
+msgstr "Actualizar el tiempo"
 
 #: src/shortcutsDialog.ui:53
 msgid "Navigation"
-msgstr "Navegacion"
+msgstr "Navegación"
 
 #~ msgid ""
 #~ "Utilizes graphical representations, such as temperature , precipitation "
@@ -1045,14 +1029,6 @@ msgstr "Navegacion"
 #~ "Utiliza representaciones graficas, tales como temperatura, precipitacion "
 #~ "graficos y velocidad del viento con direccion para proveer un prevision "
 #~ "hora a hora de las siguiente 24 horas"
-
-#, fuzzy
-#~ msgid "Clear Sky - day"
-#~ msgstr "Cielo despejado - imperial"
-
-#, fuzzy
-#~ msgid "Clear Sky - night"
-#~ msgstr "Cielo despejado - imperial"
 
 #~ msgid "United States AQI standard"
 #~ msgstr "Estandar AQI de los Estados Unidos"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-08-05 12:03-0300\n"
-"PO-Revision-Date: 2023-06-18 11:17+0300\n"
+"PO-Revision-Date: 2026-09-02 12:00+0200\n"
 "Last-Translator: capitantrueno\n"
 "Language-Team: \n"
 "Language: es_ES\n"
@@ -29,7 +29,9 @@ msgstr "El tiempo de un vistazo"
 
 #: data/io.github.amit9838.mousam.desktop.in:10
 msgid "Weather;Mousam;Rain;Cloud;Forecast;GTK4;Python;temperature;"
-msgstr "Tiempo;Meteorología;Mousam;Lluvia;Nube;Previsión;GTK4;Python;temperatura;"
+msgstr ""
+"Tiempo;Meteorología;Mousam;Lluvia;Nube;Previsión;Pronóstico;GTK4;Python;"
+"temperatura;"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:9
 msgid "Current Weather conditions and forecasts."
@@ -53,24 +55,12 @@ msgstr ""
 "Índice de calidad del aire completo y datos de contaminantes atmosféricos"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:14
-msgid "Also provides tomorrow and 7-day forecasts"
-msgstr "También ofrece previsiones para mañana y para los próximos 7 días"
+msgid "Compact weather mode for a minimal, focused view"
+msgstr "Modo de tiempo compacto para una vista mínima y centrada"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:15
-msgid "See conditions in metric or imperial systems"
-msgstr "Muestra las condiciones en sistema métrico o imperial"
-
-#: data/io.github.amit9838.mousam.appdata.xml.in:21
-msgid "Clear Sky - day"
-msgstr "Cielo despejado - día"
-
-#: data/io.github.amit9838.mousam.appdata.xml.in:25
-msgid "Snowfall - day"
-msgstr "Nevada - día"
-
-#: data/io.github.amit9838.mousam.appdata.xml.in:15
-msgid "Clear Sky - night"
-msgstr "Cielo despejado - noche"
+msgid "Hourly, tomorrow, and 7-day detailed forecasts"
+msgstr "Previsiones detalladas por horas, para mañana y a 7 días"
 
 #: data/io.github.amit9838.mousam.appdata.xml.in:16
 msgid "Visual graphs for sun and moon positions and day/night cycles"
@@ -947,7 +937,7 @@ msgstr "Habilita el registro detallado y la salida por consola"
 
 #: src/windowPreferences.py:274
 msgid "Open Logs Folder"
-msgstr "Abrir carpeta de registros"
+msgstr "Abrir la carpeta de registros"
 
 #: src/windowPreferences.py:275
 msgid "Access the application log files"
@@ -955,7 +945,7 @@ msgstr "Accede a los archivos de registro de la aplicación"
 
 #: src/windowPreferences.py:288
 msgid "Clear Log File"
-msgstr "Limpiar archivo de registros"
+msgstr "Vaciar el archivo de registro"
 
 #: src/windowPreferences.py:289
 msgid "Delete all contents of the current log file"
@@ -1020,96 +1010,3 @@ msgstr "Actualizar el tiempo"
 #: src/shortcutsDialog.ui:53
 msgid "Navigation"
 msgstr "Navegación"
-
-#~ msgid ""
-#~ "Utilizes graphical representations, such as temperature , precipitation "
-#~ "graphs and wind-speed with direction to provide an hourly forecast for "
-#~ "the next 24 hours"
-#~ msgstr ""
-#~ "Utiliza representaciones graficas, tales como temperatura, precipitacion "
-#~ "graficos y velocidad del viento con direccion para proveer un prevision "
-#~ "hora a hora de las siguiente 24 horas"
-
-#~ msgid "United States AQI standard"
-#~ msgstr "Estandar AQI de los Estados Unidos"
-
-#~ msgid "From"
-#~ msgstr "De"
-
-#~ msgid "N"
-#~ msgstr "N"
-
-#~ msgctxt "pressure card"
-#~ msgid "High"
-#~ msgstr "Alto"
-
-#~ msgctxt "pressure card"
-#~ msgid "Low"
-#~ msgstr "Bajo"
-
-#~ msgctxt "uvindex card"
-#~ msgid "High"
-#~ msgstr "Alto"
-
-#~ msgctxt "uvindex card"
-#~ msgid "Low"
-#~ msgstr "Bajo"
-
-#, fuzzy
-#~ msgid "Metric system with units like Celsius, km/h, and kilometers"
-#~ msgstr "Sistema MÉTRICO con unidades celsius, km/h, kilómetros"
-
-#, fuzzy
-#~ msgid "Imperial system with units like Fahrenheit, mph, and miles"
-#~ msgstr "Sistema IMPERIAL con unidades Farenheit, mph, millas"
-
-#, fuzzy
-#~ msgid "Switching locations within 2 seconds is ignored"
-#~ msgstr "Cambiar durante 2 segundos es ignorado!"
-
-#~ msgid "Location"
-#~ msgstr "Ubicación"
-
-#~ msgid "Could not fetch data from API"
-#~ msgstr "No se pudo obtener los datos de la API"
-
-#~ msgid "Refreshed Successfully"
-#~ msgstr "Actualizado Correctamente"
-
-#~ msgid "Refresh within 5 seconds is ignored!"
-#~ msgstr "Actualizar detro de 5 segundos es ignorado!"
-
-#~ msgid "Refreshing..."
-#~ msgstr "Actualizando..."
-
-#~ msgid "Remove location"
-#~ msgstr "Eliminar Ubicación"
-
-#~ msgid "Switch city within 2 seconds is ignored!"
-#~ msgstr "Cambiar ciudad dentro de 2 segundos es ignorado!"
-
-#~ msgid "Selected - {}"
-#~ msgstr "Seleccionado - {}"
-
-#~ msgid "Search"
-#~ msgstr "Buscar"
-
-#, python-brace-format
-#~ msgid "Added - {0}"
-#~ msgstr "Añadido - {0}"
-
-#, python-brace-format
-#~ msgid "Deleted - {0}"
-#~ msgstr "Eliminada - {0}"
-
-#~ msgid "Press enter to search"
-#~ msgstr "Presiona enter para buscar"
-
-#~ msgid "Overcast day"
-#~ msgstr "Día nublado"
-
-#~ msgid "Dark mode"
-#~ msgstr "Modo oscuro"
-
-#~ msgid "Horizon"
-#~ msgstr "Horizonte"


### PR DESCRIPTION
- correct mistranslations (Noroeste, Granos de nieve, Sistema de unidades…).
- fix spelling/grammar/gender agreement, apply Peninsular-Spanish.
- terminology and punctuation.
- translate ~55 previously untranslated strings.
- clear stale fuzzy flags.
- remove obsolete "Clear Sky - day/night" entries whose msgid duplicates active entries, causing msgfmt --check to fail.